### PR TITLE
Fix async direnv on Vim 8.0

### DIFF
--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -1,0 +1,83 @@
+" direnv.vim - support for direnv <http://direnv.net>
+" Author:       zimbatm <http://zimbatm.com/> & Hauleth <lukasz@niemier.pl>
+" Version:      0.3
+
+scriptencoding utf-8
+
+let s:direnv_cmd = get(g:, 'direnv_cmd', 'direnv')
+let s:direnv_auto = get(g:, 'direnv_auto', 1)
+let s:job_status = { 'running': 0, 'stdout': [''], 'stderr': [''] }
+
+function! direnv#auto() abort
+  return s:direnv_auto
+endfunction
+
+function! direnv#on_stdout(_, data, ...) abort
+  let s:job_status.stdout = a:data
+endfunction
+
+function! direnv#on_stderr(_, data, ...) abort
+  let s:job_status.stderr = a:data
+endfunction
+
+function! direnv#on_exit(_, status, ...) abort
+  let s:job_status.running = 0
+
+  for l:m in s:job_status.stderr
+    if l:m isnot# ''
+      echom l:m
+    endif
+  endfor
+  exec join(s:job_status.stdout, "\n")
+endfunction
+
+function! direnv#err_cb(_, data) abort
+  call direnv#on_stderr(0, split(a:data, "\n", 1))
+endfunction
+
+function! direnv#out_cb(_, data) abort
+  call direnv#on_stdout(0, split(a:data, "\n", 1))
+endfunction
+
+function! direnv#exit_cb(_, status) abort
+  call direnv#on_exit(0, a:status)
+endfunction
+
+if has('nvim')
+  let s:job =
+        \ {
+        \   'on_stdout': 'direnv#on_stdout',
+        \   'on_stderr': 'direnv#on_stderr',
+        \   'on_exit': 'direnv#on_exit'
+        \ }
+else
+  let s:job =
+        \ {
+        \   'out_cb': 'direnv#out_cb',
+        \   'err_cb': 'direnv#err_cb',
+        \   'exit_cb': 'direnv#exit_cb'
+        \ }
+endif
+
+function! direnv#export() abort
+  if !executable(s:direnv_cmd)
+    echoerr 'No Direnv executable, add it to your PATH or set correct g:direnv_cmd'
+    return
+  endif
+  if s:job_status.running
+    return
+  endif
+
+  let s:job_status.running = 1
+  let l:cmd = [s:direnv_cmd, 'export', 'vim']
+  if has('nvim')
+    call jobstart(l:cmd, s:job)
+  elseif has('job') && has('channel')
+    call job_start(l:cmd, s:job)
+  else
+    let l:tmp = tempname()
+    echom system(printf(join(l:cmd).' '.&shellredir, l:tmp))
+    exe 'source '.l:tmp
+    call delete(l:tmp)
+  endif
+endfunction

--- a/plugin/direnv.vim
+++ b/plugin/direnv.vim
@@ -2,78 +2,26 @@
 " Author:       zimbatm <http://zimbatm.com/> & Hauleth <lukasz@niemier.pl>
 " Version:      0.2
 
-if exists('g:loaded_direnv') || &cp || v:version < 700
+if exists('g:loaded_direnv') || &compatible || v:version < 700
   finish
 endif
 let g:loaded_direnv = 1
 
-let s:direnv_cmd = get(g:, 'direnv_cmd', 'direnv')
-let s:direnv_auto = get(g:, 'direnv_auto', 1)
-
-let s:job = { 'running': 0, 'stdout': [''], 'stderr': [''] }
-" NeoVim {{{
-func! s:job.on_stdout(_, data, ...) abort
-  let self.stdout[-1] .= a:data[0]
-  call extend(self.stdout, a:data[1:])
-endfunc
-func! s:job.on_stderr(_, data, ...) abort
-  let self.stderr[-1] .= a:data[0]
-  call extend(self.stderr, a:data[1:])
-endfunc
-func! s:job.on_exit(_, status, ...) abort
-  let self.running = 0
-
-  for m in self.stderr
-    if m isnot# ''
-      echom m
-    endif
-  endfor
-  exe join(self.stdout, "\n")
-endfunc
-" }}}
-" Vim {{{
-func! s:job.err_cb(_, data) abort
-  call self.on_stderr(0, split(a:data, "\n", 1))
-endfunc
-func! s:job.out_cb(_, data) abort
-  call self.on_stdout(0, split(a:data, "\n", 1))
-endfunc
-func! s:job.exit_cb(_, status) abort
-  call self.on_exit(0, a:status)
-endfunc
-" }}}
-
-func! direnv#export() abort
-  if !executable(s:direnv_cmd)
-    echoerr 'No Direnv executable, add it to your PATH or set correct g:direnv_cmd'
-    return
-  endif
-  if s:job.running
-    return
-  endif
-
-  let s:job.running = 1
-  let l:cmd = [s:direnv_cmd, 'export', 'vim']
-  if has('nvim')
-    call jobstart(l:cmd, s:job)
-  elseif has('job') && has('channel')
-    call job_start(l:cmd, s:job)
-  else
-    let l:tmp = tempname()
-    echom system(printf(join(l:cmd).' '.&shellredir, l:tmp))
-    exe 'source '.l:tmp
-    call delete(l:tmp)
-  endif
-endfunc
+" MacVim (vim 8.0) with patches 1-1272 throws an error if a job option is given
+" extra fields that it does not recognize. If the job ran even with the error
+" message, this could be fixed with `silent!`, but the job doesn't run.
+"
+" To fix this, we give `vim` an empty `s:job` dictionary that calls back to the
+" `s:job_status` dictionary. `nvim` gets `s:job` set as `s:job_status`.
 
 command! -nargs=0 DirenvExport call direnv#export()
 
-augroup envrc
+augroup direnv_rc
   au!
   autocmd BufRead,BufNewFile .envrc set filetype=sh
   autocmd BufWritePost .envrc DirenvExport
 
-  if s:direnv_auto
+  if direnv#auto()
     autocmd VimEnter * DirenvExport
 
     if exists('##DirChanged')


### PR DESCRIPTION
With the version of Vim 8.0 I have (MacVim, 8.0, patches 1-1272), I am getting this error with direnv.vim:

```
  Error detected while processing function
  .../direnv.vim/plugin/direnv.vim|60| direnv#export[14]
  E475: Invalid argument: stderr
```

It appears that in Vim 8.0, the dictionary provided to the job must not have any keys *except* the callback keys, unlike with neovim.

After several experimental implementations, this is the one that works.