### PR TITLE
debounces instead of exclusive calling

### DIFF
--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -109,7 +109,7 @@ if has('timers')
       let self.id = 0
       call direnv#export_core()
     endif
-  endif
+  endfunction
 else
   function! s:export_debounced.do()
     call direnv#export_core()

--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -5,6 +5,7 @@
 scriptencoding utf-8
 
 let s:direnv_cmd = get(g:, 'direnv_cmd', 'direnv')
+let s:direnv_interval = get(g:, 'direnv_interval', 500)
 let s:direnv_auto = get(g:, 'direnv_auto', 1)
 let s:job_status = { 'stdout': [], 'stderr': [] }
 
@@ -62,6 +63,10 @@ else
 endif
 
 function! direnv#export() abort
+  call s:export_debounced.do()
+endfunction
+
+function! direnv#export_core() abort
   if !executable(s:direnv_cmd)
     echoerr 'No Direnv executable, add it to your PATH or set correct g:direnv_cmd'
     return
@@ -79,4 +84,11 @@ function! direnv#export() abort
     exe 'source '.l:tmp
     call delete(l:tmp)
   endif
+endfunction
+
+let s:export_debounced = {'id': 0}
+
+function! s:export_debounced.do()
+  call timer_stop(self.id)
+  let self.id = timer_start(s:direnv_interval, { -> direnv#export_core() })
 endfunction

--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -6,7 +6,7 @@ scriptencoding utf-8
 
 let s:direnv_cmd = get(g:, 'direnv_cmd', 'direnv')
 let s:direnv_auto = get(g:, 'direnv_auto', 1)
-let s:job_status = { 'running': 0, 'stdout': [], 'stderr': [] }
+let s:job_status = { 'stdout': [], 'stderr': [] }
 
 function! direnv#auto() abort
   return s:direnv_auto
@@ -21,8 +21,6 @@ function! direnv#on_stderr(_, data, ...) abort
 endfunction
 
 function! direnv#on_exit(_, status, ...) abort
-  let s:job_status.running = 0
-
   for l:m in s:job_status.stderr
     if l:m isnot# ''
       echom l:m
@@ -32,7 +30,7 @@ function! direnv#on_exit(_, status, ...) abort
 endfunction
 
 function! direnv#job_status_reset() abort
-  let s:job_status = { 'running': 0, 'stdout': [], 'stderr': [] }
+  let s:job_status = { 'stdout': [], 'stderr': [] }
 endfunction
 
 function! direnv#err_cb(_, data) abort
@@ -68,12 +66,8 @@ function! direnv#export() abort
     echoerr 'No Direnv executable, add it to your PATH or set correct g:direnv_cmd'
     return
   endif
-  if s:job_status.running
-    return
-  endif
 
   call direnv#job_status_reset()
-  let s:job_status.running = 1
   let l:cmd = [s:direnv_cmd, 'export', 'vim']
   if has('nvim')
     call jobstart(l:cmd, s:job)

--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -99,15 +99,19 @@ endfunction
 let s:export_debounced = {'id': 0, 'counter': 0}
 
 if has('timers')
+  function! s:export_debounced.call(...)
+    let self.id = 0
+    let self.counter = 0
+    call direnv#export_core()
+  endfunction
+
   function! s:export_debounced.do()
     call timer_stop(self.id)
     if self.counter < s:direnv_max_wait
       let self.counter = self.counter + 1
-      let self.id = timer_start(s:direnv_interval, { -> let self.counter = 0 | direnv#export_core() })
+      let self.id = timer_start(s:direnv_interval, self.call)
     else
-      let self.counter = 0
-      let self.id = 0
-      call direnv#export_core()
+      call self.call()
     endif
   endfunction
 else


### PR DESCRIPTION
When the `direnv#export` is called many times in a short time,
only first one can be processed.

But I think that the last one should be processed.

So, I have changed the `direnv#export` debounces calling.