### PR TITLE
Add filetype & syntax highlighting (with some questions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Limitations
 The Vimscript syntax seems to limit keys to alphanumeric characters. If any
 environment variable key is something different the plugin might fail.
 
-Mainline Vim doesn't (yet) have auto command event that is fired on directory
-change, however in [NeoVim][neovim] there already is one named: `DirChange`.
-Thanks to that Direnv will be fired only on `VimEnter` (as entering Vim isn't
-directory change) and on `DirChange`.
+The newer Vim builds (>8.0.1459) & [NeoVim][neovim] have auto command event
+that is fired on directory changes, named: `DirChanged`. Thanks to that Direnv
+will be fired only on `VimEnter` (as entering Vim isn't directory change) and
+on `DirChanged`.
 
-For mainline Vim there is fallback that run on each `BufEnter` (not ideal
+For older Vim's there is fallback that run on each `BufEnter` (not ideal
 solution, but for now we have no other option).
 
 Due to asynchronous calls to Direnv if you work too fast then it can happen that

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This plugin aim is to integrate [Direnv][direnv] and [Vim][vim]. Because Vim can
 shell out to other tools it's nice if the environment is in sync with the usual
 shell.
 
-It also `set filetype=bash` for `.envrc` files.
+It also adds syntax highlighting for `.envrc` files.
 
 Features
 --------
 
 * Direnv environment loading
-* `filetype=bash` for `.envrc` files
+* filetype & syntax highlighting for `.envrc` files
 * Asynchronous running of Direnv command which won't delay your workflow.
   Supported in Vim 8 (with `job` and `channel`) or NeoVim.
 

--- a/ftdetect/direnv.vim
+++ b/ftdetect/direnv.vim
@@ -1,0 +1,5 @@
+" direnv.vim - support for direnv <http://direnv.net>
+" Author:       JINNOUCHI Yasushi <me@delphinus.dev>
+" Version:      0.2
+
+autocmd BufRead,BufNewFile .envrc setfiletype direnv

--- a/ftplugin/direnv.vim
+++ b/ftplugin/direnv.vim
@@ -1,0 +1,13 @@
+" direnv.vim - support for direnv <http://direnv.net>
+" Author:       JINNOUCHI Yasushi <me@delphinus.dev>
+" Version:      0.2
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+augroup direnv-buffer
+  autocmd! * <buffer>
+  autocmd BufWritePost <buffer> DirenvExport
+augroup END

--- a/plugin/direnv.vim
+++ b/plugin/direnv.vim
@@ -16,12 +16,9 @@ let g:loaded_direnv = 1
 
 command! -nargs=0 DirenvExport call direnv#export()
 
-augroup direnv_rc
-  au!
-  autocmd BufRead,BufNewFile .envrc set filetype=sh
-  autocmd BufWritePost .envrc DirenvExport
-
-  if direnv#auto()
+if direnv#auto()
+  augroup direnv_rc
+    au!
     autocmd VimEnter * DirenvExport
 
     if exists('##DirChanged')
@@ -29,7 +26,7 @@ augroup direnv_rc
     else
       autocmd BufEnter * DirenvExport
     endif
-  endif
-augroup END
+  augroup END
+endif
 
 " vi: fdm=marker sw=2 sts=2 et

--- a/syntax/direnv.vim
+++ b/syntax/direnv.vim
@@ -1,0 +1,89 @@
+" direnv.vim - support for direnv <http://direnv.net>
+" Author:       JINNOUCHI Yasushi <me@delphinus.dev>
+" Version:      0.2
+
+if exists('b:current_syntax')
+  finish
+endif
+
+" To use syntax for bash in sh.vim, set the g:is_bash value temporarily.
+let s:current = get(g:, 'is_bash', '__NO_VALUE__')
+let g:is_bash = 1
+runtime! syntax/sh.vim
+if s:current ==# '__NO_VALUE__'
+  unlet g:is_bash
+else
+  let g:is_bash = s:current
+endif
+unlet s:current
+
+let b:current_syntax = 'direnv'
+
+" Func: with commands {{{
+" `has` func takes one argument that represents a CLI command.
+syn keyword direnvCommandFunc has nextgroup=direnvCommand,shSingleQuote,shDoubleQuote skipwhite
+hi def link direnvCommandFunc shStatement
+
+" command name is almost the same as direnvPath, but has a different color.
+syn region direnvCommand start=/[^'"[:space:]]/ skip=/\\./ end=/\([][(){}#`'";\\[:space:]]\)\@=\|$/ contained nextgroup=shComment skipwhite
+hi def link direnvCommand shCommandSub
+" }}}
+
+" Func: with paths {{{
+" These funcs takes one argument that represents a file/dir path.
+syn keyword direnvPathFunc dotenv user_rel_path find_up source_env source_up PATH_add MANPATH_add load_prefix watch_file nextgroup=direnvPath,shSingleQuote,shDoubleQuote skipwhite
+hi def link direnvPathFunc shStatement
+
+" path string can end before non-escaped [, ], (, ), {, }, #, `, ', ", ;, \, and spaces.
+syn region direnvPath start=/[^'"[:space:]]/ skip=/\\./ end=/\([][(){}#`'";\\[:space:]]\)\@=\|$/ contained nextgroup=shComment skipwhite
+hi def link direnvPath Directory
+
+" `expand_path` takes one or two arguments that represents a dir path.
+syn keyword direnvExpandPathFunc expand_path nextgroup=direnvExpandPathRel,shSingleQuote,shDoubleQuote skipwhite
+hi def link direnvExpandPathFunc shStatement
+
+syn region direnvExpandPathRel start=/[^'"[:space:]]/ skip=/\\./ end=/\%(\s\|\_$\)/ contained nextgroup=direnvPath,shSingleQuote,shDoubleQuote skipwhite
+hi def link direnvExpandPathRel Directory
+
+" `path_add` takes two arguments that represents a variable name and a dir
+" path.
+syn keyword direnvPathAddFunc path_add nextgroup=direnvVar skipwhite
+hi def link direnvPathAddFunc shStatement
+
+syn match direnvVar /\S\+/ nextgroup=direnvPath,shSingleQuote,shDoubleQuote contained skipwhite
+hi def link direnvVar shCommandSub
+" }}}
+
+" Func: use {{{
+syn keyword direnvUseFunc use nextgroup=direnvUseCommand skipwhite
+hi def link direnvUseFunc shStatement
+
+" `use rbenv/nix/guix` takes several arguments.
+syn match direnvUseCommand /\S\+/ contained
+hi def link direnvUseCommand shCommandSub
+" }}}
+
+" Func: layout {{{
+" `layout` takes one argument that represents a language name.
+syn keyword direnvLayoutFunc layout nextgroup=direnvLayoutLanguage,direnvLayoutLanguagePath skipwhite
+hi def link direnvLayoutFunc shStatement
+
+syn keyword direnvLayoutLanguage go node perl python3 ruby contained
+hi def link direnvLayoutLanguage shCommandSub
+
+" `layout python` takes one more argument that represents a file path.
+syn keyword direnvLayoutLanguagePath python nextgroup=direnvPath,shSingleQuote,shDoubleQuote contained skipwhite
+hi def link direnvLayoutLanguagePath shCommandSub
+" }}}
+
+" Func: others {{{
+" `direnv_load` takes several arguments.
+syn keyword direnvFunc direnv_load
+hi def link direnvFunc shStatement
+" }}}
+
+syn cluster direnvStatement contains=direnvCommandFunc,direnvPathFunc,direnvExpandPathFunc,direnvPathAddFunc,direnvUseFunc,direnvLayoutFunc,direnvFunc
+syn cluster shArithParenList add=@direnvStatement
+syn cluster shCommandSubList add=@direnvStatement
+
+" vim:se fdm=marker:


### PR DESCRIPTION
This adds syntax highlighting for the original funcs from `stdlib` by Direnv.

### Features

* Separate `ftplugin` & `ftdetct` from `plugin`, because it is the Vim's way.
* Fix README for `DirChanged` event. Now Vim has it in addition to NeoVim.

### Questions

* I added my name for newly-created files for the author. Is it right? Or it should be the original authors zimbatm & Hauleth, or them and me?
* I'm not using the all features for Direnv (such as `use xxx`). I'm sorry if highlighting mistakes for them.

### Examples

<details>
<summary>sample .envrc</summary>

```sh
if has foo; then
  echo 'hello'
fi

expand_path ../foo
expand_path ../foo /Users/foobar/bar
expand_path ../foo /Users/foobar/bar /Users/foobar/bar # 3 arguments are invalid

PATH_add '/Library/Application Support/Foo/bin' # quoted paths
PATH_add /Library/Application\ Support/Foo/bin  # escaped string can be used

MANPATH_add /Library/Application\ Support/MAN_Foo
path_add FOO_PATH /usr/local/fuga

ls $(user_rel_path /home/foo/.vim/vimrc) # funcs can be in parentheses

layout go
layout perl
layout node
layout javascript # invalid arg

use ruby 1.9.3
use nix ls .vimrc
use guix ls .vimrc
use node 11.2.3
```
</details>

<img width="656" alt="スクリーンショット 2019-04-25 19 03 46" src="https://user-images.githubusercontent.com/1239245/56728038-dc436f00-678c-11e9-8ab2-57d49ebbe297.png">