### PR TITLE
Add .direnvrc to detect global setting

### DIFF
--- a/ftdetect/direnv.vim
+++ b/ftdetect/direnv.vim
@@ -2,4 +2,4 @@
 " Author:       JINNOUCHI Yasushi <me@delphinus.dev>
 " Version:      0.2
 
-autocmd BufRead,BufNewFile .envrc setfiletype direnv
+autocmd BufRead,BufNewFile .envrc,.direnvrc setfiletype direnv

--- a/ftdetect/direnv.vim
+++ b/ftdetect/direnv.vim
@@ -2,4 +2,4 @@
 " Author:       JINNOUCHI Yasushi <me@delphinus.dev>
 " Version:      0.2
 
-autocmd BufRead,BufNewFile .envrc,.direnvrc setfiletype direnv
+autocmd BufRead,BufNewFile .envrc,~/.config/direnv/direnvrc,~/.direnvrc setfiletype direnv

--- a/ftdetect/direnv.vim
+++ b/ftdetect/direnv.vim
@@ -2,4 +2,4 @@
 " Author:       JINNOUCHI Yasushi <me@delphinus.dev>
 " Version:      0.2
 
-autocmd BufRead,BufNewFile .envrc,~/.config/direnv/direnvrc,~/.direnvrc setfiletype direnv
+autocmd BufRead,BufNewFile .envrc,.direnvrc,direnvrc setfiletype direnv


### PR DESCRIPTION
I found `~/.direnvrc` is used in Direnv for the global setting. This patch detects that as `direnv` filetype.