### PR TITLE
Add commands to edit rc's

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ not to run this explicitly.
 #### `g:direnv_auto`
 
 It will not execute `DirenvExport` automatically if `let g:direnv_auto
-= 0`.
+= 0`. The default value is `1`.
 
 ### `EditDirenvrc`
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ ordered below.
 - `$XDG_CONFIG_HOME/direnv/direnvrc`
 - `~/.config/direnv/direnvrc`
 - `~/.direnvrc`
+
 If no file is open it will default to `${XDG_CONFIG_HOME:-~/.config}/direnv/direnvrc`.
+
 ### `EditEnvrc`
 
 Open the detected `.envrc` if found or a new buffer to edit `.envrc` on the

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ordered below.
 - `$XDG_CONFIG_HOME/direnv/direnvrc`
 - `~/.config/direnv/direnvrc`
 - `~/.direnvrc`
-
+If no file is open it will default to `${XDG_CONFIG_HOME:-~/.config}/direnv/direnvrc`.
 ### `EditEnvrc`
 
 Open the detected `.envrc` if found or a new buffer to edit `.envrc` on the

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ordered below.
 ### `EditEnvrc`
 
 Open the detected `.envrc` if found or a new buffer to edit `.envrc` on the
-current directory.
+current directory otherwise.
 
 #### `g:direnv_edit_mode`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ not to run this explicitly.
 
 #### `g:direnv_auto`
 
-It will not execute `DirenvExport` automatically in setting `let g:direnv_auto
+It will not execute `DirenvExport` automatically if `let g:direnv_auto
 = 0`.
 
 ### `EditDirenvrc`

--- a/README.md
+++ b/README.md
@@ -14,6 +14,46 @@ Features
 * filetype & syntax highlighting for `.envrc` files
 * Asynchronous running of Direnv command which won't delay your workflow.
   Supported in Vim 8 (with `job` and `channel`) or NeoVim.
+* Add commands to edit `direnvrc` or `.envrc`'s.
+
+Commands
+--------
+
+### `DirenvExport`
+
+Run the Direnv command and load the valid settings. This command will be
+executed automatically (and asynchronously) by `autocmd` events, so you need
+not to run this explicitly.
+
+#### `g:direnv_auto`
+
+It will not execute `DirenvExport` automatically in setting `let g:direnv_auto
+= 0`.
+
+### `EditDirenvrc`
+
+Open the global setting file for the Direnv command. This searches files
+ordered below.
+
+- `$XDG_CONFIG_HOME/direnv/direnvrc`
+- `~/.config/direnv/direnvrc`
+- `~/.direnvrc`
+
+### `EditEnvrc`
+
+Open the detected `.envrc` if found or a new buffer to edit `.envrc` on the
+current directory.
+
+#### `g:direnv_edit_mode`
+
+Select the command to open buffers to edit. The default value is `'edit'`.
+
+```vim
+" split the window before editing files
+let g:direnv_edit_mode = 'split'
+" split vertically
+let g:direnv_edit_mode = 'vsplit'
+```
 
 Limitations
 -----------

--- a/autoload/direnv/edit.vim
+++ b/autoload/direnv/edit.vim
@@ -1,0 +1,42 @@
+" direnv.vim - support for direnv <http://direnv.net>
+" Author:       JINNOUCHI Yasushi <me@delphinus.dev>
+" Version:      0.2
+
+let s:direnv_edit_mode = get(g:, 'direnv_edit_mode', 'edit')
+
+function! direnv#edit#envrc() abort
+  if $DIRENV_DIR !=# ''
+    let l:envrc_dir = substitute($DIRENV_DIR, '^-', '', '')
+  elseif expand('%') ==# ''
+    let l:envrc_dir = getcwd()
+  else
+    let l:envrc_dir = expand('%:p')
+  endif
+  let l:envrc = l:envrc_dir . '/.envrc'
+  if !filereadable(l:envrc)
+    echom 'new .envrc file will be created:' l:envrc_dir
+  endif
+  call direnv#edit#execute(l:envrc)
+endfunction
+
+function! direnv#edit#direnvrc() abort
+  if $XDG_CONFIG_HOME ==# ''
+    let l:direnvrc_dir = $HOME . '/.config/direnv'
+  else
+    let l:direnvrc_dir = $XDG_CONFIG_HOME . '/direnv'
+  endif
+  if filereadable(l:direnvrc_dir . '/direnvrc') ||
+        \ isdirectory(l:direnvrc_dir) && !filereadable($HOME . '/.direnvrc')
+    let l:direnvrc = l:direnvrc_dir . '/direnvrc'
+  else
+    let l:direnvrc = $HOME . '/.direnvrc'
+  endif
+  if !filereadable(l:direnvrc)
+    echom 'new direnvrc file will be created:' l:direnvrc
+  endif
+  call direnv#edit#execute(l:direnvrc)
+endfunction
+
+function! direnv#edit#execute(file) abort
+  execute ':' . s:direnv_edit_mode a:file
+endfunction

--- a/autoload/direnv/edit.vim
+++ b/autoload/direnv/edit.vim
@@ -7,10 +7,8 @@ let s:direnv_edit_mode = get(g:, 'direnv_edit_mode', 'edit')
 function! direnv#edit#envrc() abort
   if $DIRENV_DIR !=# ''
     let l:envrc_dir = substitute($DIRENV_DIR, '^-', '', '')
-  elseif expand('%') ==# ''
-    let l:envrc_dir = getcwd()
   else
-    let l:envrc_dir = expand('%:p')
+    let l:envrc_dir = getcwd()
   endif
   let l:envrc = l:envrc_dir . '/.envrc'
   if !filereadable(l:envrc)

--- a/autoload/direnv/edit.vim
+++ b/autoload/direnv/edit.vim
@@ -25,16 +25,32 @@ function! direnv#edit#direnvrc() abort
   else
     let l:direnvrc_dir = $XDG_CONFIG_HOME . '/direnv'
   endif
-  if filereadable(l:direnvrc_dir . '/direnvrc') ||
-        \ isdirectory(l:direnvrc_dir) && !filereadable($HOME . '/.direnvrc')
+  if filereadable(l:direnvrc_dir . '/direnvrc')
     let l:direnvrc = l:direnvrc_dir . '/direnvrc'
-  else
+  elseif filereadable($HOME . '/.direnvrc')
     let l:direnvrc = $HOME . '/.direnvrc'
+  else
+    let l:direnvrc = l:direnvrc_dir . '/direnvrc'
+    if !isdirectory(l:direnvrc_dir)
+      let l:result = direnv#edit#mkdir(l:direnvrc_dir)
+      if !l:result
+        echoerr 'Vim cannot create the directory:' l:direnvrc_dir
+        return
+      endif
+    endif
   endif
   if !filereadable(l:direnvrc)
     echom 'new direnvrc file will be created:' l:direnvrc
   endif
   call direnv#edit#execute(l:direnvrc)
+endfunction
+
+function! direnv#edit#mkdir(dir) abort
+  if !exists('*mkdir')
+    return 0
+  endif
+  let l:result = mkdir(a:dir, 'p', 0700)
+  return l:result
 endfunction
 
 function! direnv#edit#execute(file) abort

--- a/plugin/direnv.vim
+++ b/plugin/direnv.vim
@@ -15,6 +15,8 @@ let g:loaded_direnv = 1
 " `s:job_status` dictionary. `nvim` gets `s:job` set as `s:job_status`.
 
 command! -nargs=0 DirenvExport call direnv#export()
+command! -nargs=0 EditDirenvrc call direnv#edit#direnvrc()
+command! -nargs=0 EditEnvrc call direnv#edit#envrc()
 
 if direnv#auto()
   augroup direnv_rc


### PR DESCRIPTION
ref #15 

This adds two commands to edit rc's for Direnv. See details in diffs for README.

----

`EditDirenvrc` detects the file to edit in this logic below.

1. (Following is on the assumption that `$XDG_CONFIG_HOME == '~/.config'`.)
2. When `~/.config/direnv/direnvrc` is readable, it opens that.
3. When `~/.config/direnv` exists and `~/.direnvrc` does NOT exist, it opens `~/.config/direnv/direnvrc` as a new file.
4. Other than that, it opens `~/.direnvrc`.

----

(fixed because `~/.direnvrc` is deprecated, so it takes priority to `~/.config/direnv/direnvrc`)

1. When `~/.config/direnv/direnvrc` is readable, it opens that.
2. When `~/.direnvrc` is readable, it opens that.
3. It opens `~/.config/direnv/direnvrc`. If the parent directory `~/.config/direnv` does not exist, Vim makes it implicitly.