### PR TITLE
Set commentstring for shell-style comments

### DIFF
--- a/ftplugin/direnv.vim
+++ b/ftplugin/direnv.vim
@@ -11,3 +11,5 @@ augroup direnv-buffer
   autocmd! * <buffer>
   autocmd BufWritePost <buffer> DirenvExport
 augroup END
+
+setlocal commentstring=#%s


### PR DESCRIPTION
The same as `sh.vim` in the default runtime files.