### PR TITLE
NeoVim returned data can contain non-full lines

### DIFF
--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -8,28 +8,25 @@ let s:direnv_cmd = get(g:, 'direnv_cmd', 'direnv')
 let s:direnv_interval = get(g:, 'direnv_interval', 500)
 let s:direnv_max_wait = get(g:, 'direnv_max_wait', 5)
 let s:direnv_auto = get(g:, 'direnv_auto', 1)
-let s:job_status = { 'running': 0, 'stdout': [], 'stderr': [] }
+let s:job_status = { 'running': 0, 'stdout': [''], 'stderr': [''] }
 
 function! direnv#auto() abort
   return s:direnv_auto
 endfunction
 
 function! direnv#on_stdout(_, data, ...) abort
-  call extend(s:job_status.stdout, a:data)
+  let s:job_status.stdout[-1] .= a:data[0]
+  call extend(s:job_status.stdout, a:data[1:])
 endfunction
 
 function! direnv#on_stderr(_, data, ...) abort
-  call extend(s:job_status.stderr, a:data)
+  let s:job_status.stderr[-1] .= a:data[0]
+  call extend(s:job_status.stderr, a:data[1:])
 endfunction
 
 function! direnv#on_exit(_, status, ...) abort
   let s:job_status.running = 0
 
-  for l:m in s:job_status.stderr
-    if l:m isnot# ''
-      echom l:m
-    endif
-  endfor
   exec join(s:job_status.stdout, "\n")
 endfunction
 


### PR DESCRIPTION
This is documented in `:h job-control` and it suggest solution used
there.