### PR TITLE
Set commentstring

### DIFF
--- a/ftplugin/direnv.vim
+++ b/ftplugin/direnv.vim
@@ -7,6 +7,8 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
+setlocal commentstring=#\ %s
+
 augroup direnv-buffer
   autocmd! * <buffer>
   autocmd BufWritePost <buffer> DirenvExport


### PR DESCRIPTION
Lots of plugins use `commentstring` as a fallback if they don't know the filetype. For example https://github.com/tomtom/tcomment_vim:

> If tcomment doesn't know a filetype, it makes use of 'commentstring' or 'comments'.