### PR TITLE
Fix direnv.vim blocking the editor when the direnv binary is missing

### DIFF
--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -72,7 +72,7 @@ endfunction
 
 function! direnv#export_core() abort
   if !executable(s:direnv_cmd)
-    echoerr 'No Direnv executable, add it to your PATH or set correct g:direnv_cmd'
+    echom 'No Direnv executable, add it to your PATH or set correct g:direnv_cmd'
     return
   endif
 


### PR DESCRIPTION
direnv.vim currently calls `:echoerr` to notify users when the `direnv` binary isn't found in `PATH`. However, this causes vim to output 3 lines of messages which results in the hit-enter prompt to be shown, blocking the editor. This warning message can be shown frequently throughout an editing session, causing annoyances for users working on a system without the direnv binary present. This change replaces `:echoerr` with `:echom` to reduce the number of lines output to 1. This should prevent direnv.vim from blocking the editor in most configurations.

## before
<img width="1046" alt="before" src="https://user-images.githubusercontent.com/7343721/94342577-da9a6c80-004c-11eb-98b9-e0fb357a0b93.png">

## after
<img width="1046" alt="after" src="https://user-images.githubusercontent.com/7343721/94342578-dec68a00-004c-11eb-8630-8b1ea636924f.png">
