### PR TITLE
Emit an event upon completion of direnv export.

### DIFF
--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -18,6 +18,11 @@ function! direnv#auto() abort
   return s:direnv_auto
 endfunction
 
+function! direnv#after_loaded() abort
+  call direnv#extra_vimrc#load()
+  doautocmd User DirenvLoaded
+endfunction
+
 function! direnv#on_stdout(_, data, ...) abort
   call extend(s:job_status.stdout, a:data)
 endfunction
@@ -37,7 +42,7 @@ function! direnv#on_exit(_, status, ...) abort
     endfor
   endif
   exec join(s:job_status.stdout, "\n")
-  call direnv#extra_vimrc#load()
+  call direnv#after_loaded()
 endfunction
 
 function! direnv#job_status_reset() abort
@@ -100,6 +105,7 @@ function! direnv#export_core() abort
     echom system(printf(join(l:cmd).' '.&shellredir, l:tmp))
     exe 'source '.l:tmp
     call delete(l:tmp)
+    call direnv#after_loaded()
   endif
 endfunction
 

--- a/autoload/direnv.vim
+++ b/autoload/direnv.vim
@@ -18,7 +18,7 @@ function! direnv#auto() abort
   return s:direnv_auto
 endfunction
 
-function! direnv#after_loaded() abort
+function! direnv#post_direnv_load() abort
   call direnv#extra_vimrc#load()
   doautocmd User DirenvLoaded
 endfunction
@@ -42,7 +42,7 @@ function! direnv#on_exit(_, status, ...) abort
     endfor
   endif
   exec join(s:job_status.stdout, "\n")
-  call direnv#after_loaded()
+  call direnv#post_direnv_load()
 endfunction
 
 function! direnv#job_status_reset() abort
@@ -105,7 +105,7 @@ function! direnv#export_core() abort
     echom system(printf(join(l:cmd).' '.&shellredir, l:tmp))
     exe 'source '.l:tmp
     call delete(l:tmp)
-    call direnv#after_loaded()
+    call direnv#post_direnv_load()
   endif
 endfunction
 

--- a/autoload/direnv/extra_vimrc.vim
+++ b/autoload/direnv/extra_vimrc.vim
@@ -22,7 +22,7 @@ function! direnv#extra_vimrc#check() abort
     let l:direnv_dir = substitute($DIRENV_DIR, '^-', '', '')
     " TODO think about Windows?
     if stridx(l:filedir, l:direnv_dir) == 0
-      call direnv#extra_vimrc#load()
+      call direnv#post_direnv_load()
     endif
   endif
 endfunction


### PR DESCRIPTION
This emits a `DirenvLoaded` User autocmd event when the plugin is finished and has loaded the direnv export as well as any potential local vimrc files.

This allows for an elegant and robust solution to #19 that lets you *also* run vim code that depends on tools only exposed through direnv. For example, I'm using this right now along with vim-rooter to conditionally reload-or-start language servers without race conditions or having to first enter a nix-shell.