### PR TITLE
Fix #30: Avoid errors on loading

### DIFF
--- a/plugin/direnv.vim
+++ b/plugin/direnv.vim
@@ -23,6 +23,8 @@ if direnv#auto()
     au!
     autocmd VimEnter * DirenvExport
     autocmd BufEnter * call direnv#extra_vimrc#check()
+    " need this to avoid an error on loading
+    autocmd User DirenvLoaded :
 
     if exists('##DirChanged')
       autocmd DirChanged * DirenvExport


### PR DESCRIPTION
`doautocmd User` raises an error when there are no definitions for this.